### PR TITLE
Add spacing to fix italics

### DIFF
--- a/content/notes/wwdc20/10651.md
+++ b/content/notes/wwdc20/10651.md
@@ -29,6 +29,7 @@ A Safari App Clip Banner shows on an Associated Domain. Tapping the banner's Ope
 Two new categories of API functionality have been added, with a total of more than 200 new endpoints.
 
 App Metadata:
+
 * Create a new version
 * Set app pricing
 * Edit app and version metadata
@@ -36,5 +37,6 @@ App Metadata:
 * Submit for App Review
 
 Power and Performance:
+
 * Metrics and diagnostics
 * Download the same aggregate data that drives the new Power and Performance analysis tools in Xcode


### PR DESCRIPTION
Looks like there's an issue with formatting in the last section, I'm guessing it's the lack of a new line before the bulletpoints:

![image](https://user-images.githubusercontent.com/10298140/87168042-336c2b80-c2ce-11ea-86ec-7a1e48df88ca.png)
